### PR TITLE
Override the default /home command

### DIFF
--- a/skyblock_levels/register_command.lua
+++ b/skyblock_levels/register_command.lua
@@ -46,3 +46,22 @@ minetest.register_chatcommand('who', {
 		end
 	end,
 })
+
+if not minetest.get_modpath("sethome") then
+	minetest.register_privilege("home", {
+		description = "Can use /home",
+		give_to_singleplayer = true
+	})
+end
+
+minetest.override_chatcommand('home', {
+	privs = {home=true},
+    	description = "Teleports you to your spawn position",
+    	func = function(name)
+      		local spawn = skyblock.get_spawn(name)
+      		local pos = {x = spawn.x, y = spawn.y + 1.5, z= spawn.z}
+      		local player = minetest.get_player_by_name(name)
+      		player:setpos(pos)
+       		return
+    	end,
+})


### PR DESCRIPTION
overrides the home command so the player always returns to their spawn and registers the home command if sethome mod is removed from minetest_game