### PR TITLE
create startblock and island once only

### DIFF
--- a/mods/skyblock/skyblock/skyblock.lua
+++ b/mods/skyblock/skyblock/skyblock.lua
@@ -140,10 +140,10 @@ function skyblock.spawn_player(player)
 	if spawn == nil then
 		spawn = skyblock.get_next_spawn()
 		skyblock.set_spawn(player_name,spawn)
+		-- add the start block
+		skyblock.make_spawn_blocks(spawn,player_name)
 	end
-	
-	-- add the start block and teleport the player
-	skyblock.make_spawn_blocks(spawn,player_name)
+	-- teleport player
 	player:setpos({x=spawn.x,y=spawn.y+6,z=spawn.z})
 	player:set_hp(20)
 end


### PR DESCRIPTION
This change only creates the startblock and island when a new player joins.