### PR TITLE
Create skyblock island only on level 1

### DIFF
--- a/mods/skyblock/skyblock/skyblock.lua
+++ b/mods/skyblock/skyblock/skyblock.lua
@@ -140,10 +140,10 @@ function skyblock.spawn_player(player)
 	if spawn == nil then
 		spawn = skyblock.get_next_spawn()
 		skyblock.set_spawn(player_name,spawn)
-		-- add the start block island
-		minetest.after(3.0, function()
-			skyblock.make_spawn_blocks(spawn,player_name)
-		end)
+	end
+	-- generate player island only for level 1
+	if skyblock.feats.get_level(player_name) == 1 then
+		skyblock.make_spawn_blocks(spawn,player_name)
 	end
 	-- teleport player
 	player:setpos({x=spawn.x,y=spawn.y+6,z=spawn.z})

--- a/mods/skyblock/skyblock/skyblock.lua
+++ b/mods/skyblock/skyblock/skyblock.lua
@@ -140,10 +140,12 @@ function skyblock.spawn_player(player)
 	if spawn == nil then
 		spawn = skyblock.get_next_spawn()
 		skyblock.set_spawn(player_name,spawn)
+		-- add the start block island
+		minetest.after(3.0, function()
+			skyblock.make_spawn_blocks(spawn,player_name)
+		end)
 	end
-	
-	-- add the start block and teleport the player
-	skyblock.make_spawn_blocks(spawn,player_name)
+	-- teleport player
 	player:setpos({x=spawn.x,y=spawn.y+6,z=spawn.z})
 	player:set_hp(20)
 end


### PR DESCRIPTION
This pull has the skyblock island spawn only when player is on level 1 so they can finish dirt challenges.